### PR TITLE
Fixed the exefs filesystem parser such that it doesnt attempt to deco…

### DIFF
--- a/src/main/kotlin/com/martmists/ctr/loader/filesystem/CXIFileSystem.kt
+++ b/src/main/kotlin/com/martmists/ctr/loader/filesystem/CXIFileSystem.kt
@@ -121,7 +121,7 @@ class CXIFileSystem(private val fsFSRL: FSRLRoot, private var provider: ByteProv
                 val exefsStart = tell()
                 val codeSection = exefsHeader.fileHeaders_10.first { it.filename_8.stripNulls() == fileName }
 
-                val size = if (metadata.ncchEx.sci.flags and 0x1 == 1.toByte()) {
+                val size = if (metadata.ncchEx.sci.flags and 0x1 == 1.toByte() && fileName.stripNulls() == ".code") {
                     skip(codeSection.offset.toLong())
                     val exefsCode = readBytes(codeSection.size)
                     exefsCode.lzssSize()
@@ -133,7 +133,7 @@ class CXIFileSystem(private val fsFSRL: FSRLRoot, private var provider: ByteProv
                     provider.getInputStream(0).reader {
                         seek(exefsStart + codeSection.offset)
                         var code = readBytes(codeSection.size)
-                        if (metadata.ncchEx.sci.flags and 0x1 == 1.toByte()) {
+                        if (metadata.ncchEx.sci.flags and 0x1 == 1.toByte()  && fileName.stripNulls() == ".code") {
                             code = code.lzss()
                         }
                         out.write(code)


### PR DESCRIPTION
The codebase was attempting to lzss decompress the banner and icon elements of the exeFS when loading the Alpha Sapphire cxi, which according to the exeFS documentation here, do not get LZSS compressed: https://www.3dbrew.org/wiki/ExeFS

As such, it was reading junk data.

This PR adds a quick check to the CXIFileSystem methods to ensure that exeFS files that are not compressed do not have the lzss decompression algorithm run on them.